### PR TITLE
Fix indentation in pnpm-lock.yaml

### DIFF
--- a/horsetrust/pnpm-lock.yaml
+++ b/horsetrust/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       dotenv:
-      specifier: ^17.3.1
+        specifier: ^17.3.1
         version: 17.3.1
       jsonwebtoken:
         specifier: ^9.0.3


### PR DESCRIPTION
Dejé mal una identacion de un paquete cuando hice el merge y tenia conflictos, aqui lo corregí.